### PR TITLE
Allow InstancedNode to be transformed independently of its Node

### DIFF
--- a/include/core/Scene.hpp
+++ b/include/core/Scene.hpp
@@ -9,17 +9,6 @@
 class Mesh;
 struct Node;
 
-// The model matrix needs to be cached because the performance would be awful otherwise.
-// However, caching the matrix in the `Node` itself would result in issues when the node is rendered multiple times.
-struct InstancedNode {
-    Node const* node;
-    glm::mat4 model_matrix{0.0f};
-    std::vector<InstancedNode> children;
-
-    void traverse(std::function<void(glm::mat4, Node const&)>) const;
-    void compute_transforms(glm::mat4 = glm::mat4{1.0f});
-};
-
 struct Transform {
     glm::vec3 position;
     glm::quat orientation;
@@ -28,6 +17,19 @@ struct Transform {
     [[nodiscard]] glm::mat4 get_local_matrix() const;
     [[nodiscard]] glm::vec3 orientation_euler() const;
     void set_orientation_euler(glm::vec3);
+};
+
+// The model matrix needs to be cached because the performance would be awful otherwise.
+// However, caching the matrix in the `Node` itself would result in issues when the node is rendered multiple times.
+// To be able to change the transform of each instances separately, InstancedNode needs its own transform component.
+struct InstancedNode {
+    Transform transform;
+    Node const* node;
+    glm::mat4 model_matrix{0.0f};
+    std::vector<InstancedNode> children;
+
+    void traverse(std::function<void(glm::mat4, Node const&)>) const;
+    void compute_transforms(glm::mat4 = glm::mat4{1.0f});
 };
 
 struct Node {

--- a/src/core/Scene.cpp
+++ b/src/core/Scene.cpp
@@ -34,6 +34,7 @@ Node Node::create(std::string name, Transform t)
 InstancedNode Node::instanciate() const
 {
     InstancedNode new_node{
+        .transform = transform,
         .node = this,
         .model_matrix = glm::mat4{},
         .children = {},
@@ -56,7 +57,7 @@ void InstancedNode::traverse(std::function<void(glm::mat4, Node const&)> f) cons
 
 void InstancedNode::compute_transforms(glm::mat4 parent_transform)
 {
-    model_matrix = parent_transform * node->transform.get_local_matrix();
+    model_matrix = parent_transform * transform.get_local_matrix();
     for (auto& child : children) {
         child.compute_transforms(model_matrix);
     }


### PR DESCRIPTION
This is a fix for an oversight in https://github.com/pixelsandpointers/3d/pull/22, which prevented the transform of a node instance from being changed independently of its node.

However, we need to be able to change the transform to be able to reposition and rotate objects in the scene.