### PR TITLE
ui: Add functionality to ObjectSelectionTree/ObjectDetails

### DIFF
--- a/include/core/Project.hpp
+++ b/include/core/Project.hpp
@@ -24,6 +24,8 @@ struct FSCacheNode {
 class Project {
 public:
     std::filesystem::path root;
+    InstancedNode* selected_node{nullptr};
+    std::optional<InstancedNode> scene;
 
     static Project* get_current();
     static void load(std::filesystem::path);

--- a/include/core/Scene.hpp
+++ b/include/core/Scene.hpp
@@ -27,6 +27,7 @@ struct InstancedNode {
     Node const* node;
     glm::mat4 model_matrix{0.0f};
     std::vector<InstancedNode> children;
+    std::string name;
 
     void traverse(std::function<void(glm::mat4, Node const&)>) const;
     void compute_transforms(glm::mat4 = glm::mat4{1.0f});

--- a/include/ui/ObjectSelectionTree.hpp
+++ b/include/ui/ObjectSelectionTree.hpp
@@ -4,6 +4,6 @@
 
 struct ObjectSelectionTree {
     ObjectSelectionTree();
-    void traverse_nodes(InstancedNode const& root);
-    void render(InstancedNode const& root);
+    void traverse_nodes(InstancedNode& root);
+    void render();
 };

--- a/src/core/Scene.cpp
+++ b/src/core/Scene.cpp
@@ -38,6 +38,7 @@ InstancedNode Node::instanciate() const
         .node = this,
         .model_matrix = glm::mat4{},
         .children = {},
+        .name = name,
     };
 
     for (auto const& child : children) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,7 @@ int main()
     auto path = std::filesystem::current_path() / "assets";
     std::cout << path.string().c_str() << std::endl;
     Project::load(path);
+    auto project = Project::get_current();
     path.append("Models/TUD_Innenstadt.FBX");
 
     // INIT UI
@@ -89,7 +90,7 @@ int main()
     auto viewing_mode = shader_uniform_pane.viewing_mode;
 
     auto camera_controller = CameraController{CameraController::Type::FREECAM, glm::vec3{0.f, 0.f, -3.f}};
-    auto obj = Project::get_current()->get_model(path);
+    auto obj = project->get_model(path);
 
     auto asset_browser = AssetBrowser{};
 
@@ -106,8 +107,8 @@ int main()
     auto scene = Node::create("scene", root_transform);
     scene.children.push_back(*obj);
 
-    auto scene_instance = scene.instanciate();
-    scene_instance.compute_transforms();
+    project->scene = scene.instanciate();
+    project->scene->compute_transforms();
     auto last_frame = glfwGetTime();
 
     // to adjust the shader values, introduce a map here with the uniforms being passed to the draw call,
@@ -129,7 +130,7 @@ int main()
 
         camera_controller.update(delta_time);
 
-        Project::get_current()->rebuild_fs_cache_timed(current_frame);
+        project->rebuild_fs_cache_timed(current_frame);
 
         /* Render here */
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -141,7 +142,7 @@ int main()
             glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
         }
 
-        camera_controller.camera->draw(shader, shader_uniform_pane.uniforms, framebuffer, scene_instance);
+        camera_controller.camera->draw(shader, shader_uniform_pane.uniforms, framebuffer, project->scene.value());
 
         // Render GUI
         ImGui_ImplOpenGL3_NewFrame();
@@ -149,7 +150,7 @@ int main()
         ImGui::NewFrame();
 
         object_details_pane.render();
-        object_selection_tree.render(scene_instance);
+        object_selection_tree.render();
         shader_uniform_pane.render();
         asset_browser.render();
 

--- a/src/ui/ObjectDetails.cpp
+++ b/src/ui/ObjectDetails.cpp
@@ -1,13 +1,14 @@
 #include "ui/ObjectDetails.hpp"
+#include "core/Project.hpp"
 #include <imgui.h>
 #include <string>
+
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/gtx/euler_angles.hpp>
 
 ObjectDetails::ObjectDetails() = default;
 
 char object_label[128] = {""};
-float rotation[3][128] = {{0}, {0}, {0}};
-float scale[3][128] = {{1}, {1}, {1}};
-float position[3][128] = {{0}, {0}, {0}};
 bool toggle_shading = false;
 
 void ObjectDetails::render()
@@ -19,21 +20,38 @@ void ObjectDetails::render()
     ImVec2 child_pos = ImVec2(0, 0);
     ImGui::SetNextWindowPos(child_pos);
 
+    auto transform_changed = false;
+    auto project = Project::get_current();
+    auto node = project->selected_node;
+
     // Apply size constraint before creating the window
     ImGui::SetNextWindowSizeConstraints(min_size, max_size);
     if (ImGui::Begin("Object Details", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove)) {
+        if (!node) {
+            ImGui::Text("No node selected");
+            ImGui::End();
+            return;
+        }
 
-        ImGui::InputText("Label", object_label, IM_ARRAYSIZE(object_label));
+        std::strcpy(object_label, node->name.c_str());
+        if (ImGui::InputText("Label", object_label, IM_ARRAYSIZE(object_label))) {
+            node->name = object_label;
+        }
 
         char const* rotation_labels[] = {"X##rotation0", "Y##rotation1", "Z##rotation2"};
         char const* scale_labels[] = {"X##scale0", "Y##scale1", "Z##scale2"};
         char const* position_labels[] = {"X##position0", "Y##position1", "Z##position2"};
 
         // Rotation Row
+        auto rotation = glm::degrees(glm::eulerAngles(node->transform.orientation));
         ImGui::Text("Rotation");
         for (int i = 0; i < 3; i++) {
             ImGui::PushItemWidth(100); // Set width for uniformity
-            ImGui::InputFloat(rotation_labels[i], rotation[i], 0.1f, 1.0f, "%.3f");
+            if (ImGui::InputFloat(rotation_labels[i], &rotation[i], 0.1f, 1.0f, "%.3f")) {
+                auto euler_rad = glm::radians(rotation);
+                node->transform.orientation = glm::eulerAngleXYZ(euler_rad.x, euler_rad.y, euler_rad.z);
+                transform_changed = true;
+            }
             ImGui::PopItemWidth();
             if (i < 2)
                 ImGui::SameLine(); // Keep on same row
@@ -43,7 +61,9 @@ void ObjectDetails::render()
         ImGui::Text("Scale");
         for (int i = 0; i < 3; i++) {
             ImGui::PushItemWidth(100);
-            ImGui::InputFloat(scale_labels[i], scale[i], 0.1f, 1.0f, "%.3f");
+            if (ImGui::InputFloat(scale_labels[i], &node->transform.scale[i], 1.0f, 10.0f, "%.3f")) {
+                transform_changed = true;
+            }
             ImGui::PopItemWidth();
             if (i < 2)
                 ImGui::SameLine();
@@ -53,11 +73,17 @@ void ObjectDetails::render()
         ImGui::Text("Position");
         for (int i = 0; i < 3; i++) {
             ImGui::PushItemWidth(100);
-            ImGui::InputFloat(position_labels[i], position[i], 0.1f, 1.0f, "%.3f");
+            if (ImGui::InputFloat(position_labels[i], &node->transform.position[i], 1.0f, 10.0f, "%.3f")) {
+                transform_changed = true;
+            }
             ImGui::PopItemWidth();
             if (i < 2)
                 ImGui::SameLine();
         }
+    }
+
+    if (project->scene && transform_changed) {
+        project->scene->compute_transforms();
     }
 
     ImGui::End();

--- a/src/ui/ObjectSelectionTree.cpp
+++ b/src/ui/ObjectSelectionTree.cpp
@@ -1,21 +1,32 @@
 #include "ui/ObjectSelectionTree.hpp"
+#include "core/Project.hpp"
 #include "imgui.h"
 
 constexpr auto imgui_treenode_leaf_flags = ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_Bullet | ImGuiTreeNodeFlags_NoTreePushOnOpen;
 
 ObjectSelectionTree::ObjectSelectionTree() = default;
 
-void ObjectSelectionTree::traverse_nodes(InstancedNode const& root)
+void ObjectSelectionTree::traverse_nodes(InstancedNode& root)
 {
-    for (auto const& child : root.children) {
+    auto* project = Project::get_current();
+
+    for (auto& child : root.children) {
         ImGui::TableNextRow();
         ImGui::TableNextColumn();
         bool open = false;
 
+        auto flags_selected = &child == project->selected_node
+            ? ImGuiTreeNodeFlags_Selected
+            : ImGuiTreeNodeFlags_None;
+
         if (!child.children.empty()) {
-            open = ImGui::TreeNodeEx(child.node->name.c_str());
+            open = ImGui::TreeNodeEx(child.name.c_str(), flags_selected);
         } else {
-            ImGui::TreeNodeEx(child.node->name.c_str(), imgui_treenode_leaf_flags);
+            ImGui::TreeNodeEx(child.name.c_str(), imgui_treenode_leaf_flags | flags_selected);
+        }
+
+        if (ImGui::IsItemClicked()) {
+            project->selected_node = &child;
         }
 
         if (open) {
@@ -25,13 +36,17 @@ void ObjectSelectionTree::traverse_nodes(InstancedNode const& root)
     }
 }
 
-void ObjectSelectionTree::render(InstancedNode const& root)
+void ObjectSelectionTree::render()
 {
     if (ImGui::Begin("Object Tree")) {
-        if (ImGui::BeginTable("table0", 1)) {
-            traverse_nodes(root);
+        if (auto& scene = Project::get_current()->scene; scene.has_value()) {
+            if (ImGui::BeginTable("table0", 1)) {
+                traverse_nodes(scene.value());
+            }
+            ImGui::EndTable();
+        } else {
+            ImGui::Text("No scene open");
         }
-        ImGui::EndTable();
     }
 
     ImGui::End();


### PR DESCRIPTION
Closes https://github.com/pixelsandpointers/3d/issues/15
Closes https://github.com/pixelsandpointers/3d/issues/14

Allows selecting a node using the object selection tree and editing it using the "Object Details" window.
The "Shading" checkbox currently does nothing.

To implement this behavior, I also had to add the scene and a pointer to the selected node to `Project`.
Editing the name of an `InstancedNode` independently of it's underlying `Node` is now possible.