### PR TITLE
Load mask textures / Transparent Trees

### DIFF
--- a/include/core/Project.hpp
+++ b/include/core/Project.hpp
@@ -15,6 +15,8 @@ struct FSCacheNode {
         DIRECTORY,
         MODEL,
         TEXTURE,
+        UNITY_MATERIAL,
+        UNITY_META,
         OTHER,
     };
 
@@ -39,6 +41,7 @@ public:
 
     FSCacheNode* get_fs_cache();
     FSCacheNode* get_fs_cache(std::filesystem::path);
+    std::optional<std::filesystem::path> get_fs_cache_from_guid(std::string const&) const;
     Texture const* get_texture(std::filesystem::path);
     Node* get_model(std::filesystem::path);
     Node* get_cached_model(std::filesystem::path);
@@ -56,7 +59,9 @@ private:
     std::unordered_map<std::filesystem::path, Node> m_models;
     std::unique_ptr<FSCacheNode> m_fs_cache;
     double m_fs_cache_last_updated{0};
+    std::unordered_map<std::string, std::filesystem::path> m_guid_mappings;
 
     Project(std::filesystem::path);
     void rebuild_fs_cache();
+    void rebuild_fs_cache_helper(FSCacheNode&);
 };

--- a/include/renderer/Mesh.hpp
+++ b/include/renderer/Mesh.hpp
@@ -25,11 +25,13 @@ public:
     std::vector<Vertex> m_vertices;
     std::vector<unsigned int> m_indices;
     Texture const* m_texture_diffuse;
+    Texture const* m_texture_opacity;
     AABB aabb;
 
     Mesh(std::vector<Vertex> vertices,
         std::vector<unsigned int> indices,
         Texture const* texture_diffuse,
+        Texture const* texture_opacity,
         AABB);
 
     void draw() const;

--- a/src/renderer/Mesh.cpp
+++ b/src/renderer/Mesh.cpp
@@ -2,10 +2,11 @@
 
 #include "core/Project.hpp"
 
-Mesh::Mesh(std::vector<Vertex> vertices, std::vector<unsigned int> indices, Texture const* texture_diffuse, AABB aabb)
+Mesh::Mesh(std::vector<Vertex> vertices, std::vector<unsigned int> indices, Texture const* texture_diffuse, Texture const* texture_opacity, AABB aabb)
     : m_vertices(vertices)
     , m_indices(indices)
     , m_texture_diffuse(texture_diffuse)
+    , m_texture_opacity(texture_opacity)
     , aabb(aabb)
 {
     setup_mesh();
@@ -25,8 +26,13 @@ void Mesh::draw(ViewingMode mode) const
 
     // set diffuse texture
     glActiveTexture(GL_TEXTURE0);
-    glUniform1i(glGetUniformLocation(shader.m_id, "texture_diffuse"), 0);
+    shader.set_int("texture_diffuse", 0);
     glBindTexture(GL_TEXTURE_2D, diffuse_texture_id);
+
+    // set opacity texture
+    glActiveTexture(GL_TEXTURE1);
+    shader.set_int("texture_opacity", 1);
+    glBindTexture(GL_TEXTURE_2D, m_texture_opacity->m_id);
 
     // set active
     glBindVertexArray(m_vao);

--- a/src/renderer/Shader.cpp
+++ b/src/renderer/Shader.cpp
@@ -31,14 +31,21 @@ auto const albedo_source = ShaderSource{
         #version 410 core
         out vec4 FragColor;
         in vec2 TexCoords;
+        in vec4 gl_FragCoord;
 
         uniform sampler2D texture_diffuse;
+        uniform sampler2D texture_opacity;
         uniform float gamma;
 
         void main() {
             vec3 color = texture(texture_diffuse, TexCoords).rgb;
             vec3 gammaCorrection = pow(color, vec3(1. / gamma));
-            FragColor = vec4(gammaCorrection, 1.);
+            FragColor = vec4(gammaCorrection, 1.0f);
+
+            float alpha = texture(texture_opacity, TexCoords).r;
+            if (alpha <= 0.01f) {
+                discard;
+            };
         })",
 };
 
@@ -80,8 +87,10 @@ auto const lighting_source = ShaderSource{
         in vec3 FragPos;
         in vec3 Normal;
         in vec2 TexCoords;
+        in vec4 gl_FragCoord;
 
         uniform sampler2D texture_diffuse;
+        uniform sampler2D texture_opacity;
         uniform Light light;
         uniform vec3 cameraPos;
         uniform float ambientStrength;
@@ -112,7 +121,12 @@ auto const lighting_source = ShaderSource{
             vec3 color = ambient + diffuse * light.color + specular * light.color;
 
             vec3 gammaCorrection = pow(color, vec3(1. / gamma));
-            FragColor = vec4(gammaCorrection, 1.);
+            FragColor = vec4(gammaCorrection, 1.0f);
+
+            float alpha = texture(texture_opacity, TexCoords).r;
+            if (alpha <= 0.01f) {
+                discard;
+            };
         })",
 };
 


### PR DESCRIPTION
Closes #23 

![2025-02-17_20-03](https://github.com/user-attachments/assets/e094cf7d-7862-4414-af33-eb316ffedf20)


I doesn't work quite right for now, but the trees look less broken here than in Unity!
However, most (all?) railings don't have any transparency at all, apparently because not all mask textures can be found.

The transparency in this PR is implemented by discarding fully transparent fragments. Partial transparency is not implemented, because I don't know how to do depth ordering here, especially since the trees consist of very few overlapping triangles. This is also what goes wrong in Unity.