### PR TITLE
Fix outline artifacts on viewport edge

### DIFF
--- a/src/renderer/Camera.cpp
+++ b/src/renderer/Camera.cpp
@@ -29,6 +29,8 @@ Framebuffer Framebuffer::create_simple(int width, int height)
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, fb.width, fb.height, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, fb.color_texture, 0);
 
     glGenRenderbuffers(1, &fb.depth_rbo);


### PR DESCRIPTION
The wrap mode of framebuffer textures was not specified and apparently defaulted to GL_REPEAT.
This caused some artifacts on the top edge of the viewport window when the outline of a selected object was in view and the object was cut off by the bottom edge of the viewport.