### PR TITLE
Remove broken outline in AssetBrowser model preview

### DIFF
--- a/include/renderer/Camera.hpp
+++ b/include/renderer/Camera.hpp
@@ -52,10 +52,10 @@ public:
     // constructor with vectors
     Camera(glm::vec3 position, glm::vec3 target, float fov = glm::radians(90.0f));
 
-    void draw(ViewingMode,
-        Uniforms const&,
-        Framebuffer const&,
-        InstancedNode const&);
+    void draw(ViewingMode, Uniforms const&, Framebuffer const&, InstancedNode const&);
+
+    // The `draw` function must be called before `draw_outline`.
+    void draw_outline(Framebuffer const&, InstancedNode const&);
 
 private:
     Framebuffer m_mask_framebuffer{Framebuffer::create_simple(1, 1)};

--- a/src/ui/Viewport.cpp
+++ b/src/ui/Viewport.cpp
@@ -37,6 +37,9 @@ void Viewport::render(double delta_time)
         m_camera_controller.rotation_speed = config.rotation_speed;
         m_camera_controller.zoom_speed = config.zoom_speed;
         m_camera_controller.camera->draw(config.viewing_mode, config.viewport_uniforms, m_framebuffer, *project->scene);
+        if (project->selected_node) {
+            m_camera_controller.camera->draw_outline(m_framebuffer, *project->selected_node);
+        }
 
         config.camera_position = m_camera_controller.camera->position;
         config.camera_target = m_camera_controller.camera->target;


### PR DESCRIPTION
Extracts the outline drawing code into a new function `Camera::draw_outline` that is only called by the `Viewport`, not by the `AssetBrowser`.