### PR TITLE
Focus the Viewport window with middle and right mouse buttons

### DIFF
--- a/src/ui/Viewport.cpp
+++ b/src/ui/Viewport.cpp
@@ -1,6 +1,7 @@
 #include "ui/Viewport.hpp"
 
 #include "core/Project.hpp"
+#include <imgui_internal.h>
 
 Viewport::Viewport()
     : m_framebuffer{Framebuffer::create_simple(1, 1)}
@@ -43,6 +44,12 @@ void Viewport::render(double delta_time)
 
         ImGui::Image(m_framebuffer.color_texture, ImVec2(m_framebuffer.width, m_framebuffer.height), ImVec2{0.0f, 1.0f}, ImVec2{1.0f, 0.0f});
     }
+
+    // Focus Viewport window not only with the left, but also the middle and right mouse button.
+    if (!ImGui::IsWindowFocused() && ImGui::IsWindowHovered() && (ImGui::IsMouseDown(ImGuiMouseButton_Middle) || ImGui::IsMouseDown(ImGuiMouseButton_Right))) {
+        ImGui::FocusWindow(ImGui::GetCurrentWindow());
+    }
+
     ImGui::End();
     ImGui::PopStyleVar();
 }


### PR DESCRIPTION
Because the middle and right mouse buttons are used by most camera controllers, this is necessary to start moving the camera even if the Viewport window is not focused beforehand.