### PR TITLE
Only handle scroll in CameraController when Viewport is hovered

### DIFF
--- a/include/core/CameraController.hpp
+++ b/include/core/CameraController.hpp
@@ -23,10 +23,10 @@ struct CameraController {
 
     float zoom_speed{1.0f};
 
-    void update(float delta_time);
+    void update(float delta_time, bool handle_scroll);
 
 private:
-    void update_freecam(float delta_time);
-    void update_blender(float delta_time);
-    void update_unity(float delta_time);
+    void update_freecam(float delta_time, bool handle_scroll);
+    void update_blender(float delta_time, bool handle_scroll);
+    void update_unity(float delta_time, bool handle_scroll);
 };

--- a/src/ui/Viewport.cpp
+++ b/src/ui/Viewport.cpp
@@ -20,7 +20,7 @@ void Viewport::render(double delta_time)
         m_camera_controller.camera->target = config.camera_target;
 
         if (ImGui::IsWindowFocused()) {
-            m_camera_controller.update(delta_time);
+            m_camera_controller.update(delta_time, ImGui::IsWindowHovered());
         }
 
         auto size = ImGui::GetContentRegionAvail();


### PR DESCRIPTION
Fixes the camera moving when scrolling in some other window, e.g. ObjectSelectionTree.