### PR TITLE
Add reset button to ObjectDetails

### DIFF
--- a/include/core/Scene.hpp
+++ b/include/core/Scene.hpp
@@ -35,6 +35,9 @@ struct InstancedNode {
 
     void traverse(std::function<void(glm::mat4, Node const&)>) const;
     void compute_transforms(glm::mat4 = glm::mat4{1.0f});
+
+    // This function is slow and should only be sparingly used and only when absolutely necessary.
+    [[nodiscard]] InstancedNode* find_parent(InstancedNode& scene) const;
 };
 
 struct NodeLocation {

--- a/src/core/Scene.cpp
+++ b/src/core/Scene.cpp
@@ -85,6 +85,21 @@ void InstancedNode::compute_transforms(glm::mat4 parent_transform)
     }
 }
 
+InstancedNode* InstancedNode::find_parent(InstancedNode& scene) const
+{
+    for (auto& child : scene.children) {
+        if (child.get() == this) {
+            return &scene;
+        }
+
+        if (auto parent = find_parent(*child)) {
+            return parent;
+        }
+    }
+
+    return nullptr;
+}
+
 NodeLocation NodeLocation::empty()
 {
     return NodeLocation{


### PR DESCRIPTION
When playing with the gizmos, I often mangle the objects pretty badly and then have to resort to delete the scene file. So this PR adds a button that either resets the object's transform or completely resets the object including any child objects.