### PR TITLE
Fix target for Blender camera controller being discard on load

### DIFF
--- a/src/ui/Viewport.cpp
+++ b/src/ui/Viewport.cpp
@@ -34,6 +34,13 @@ void Viewport::render(double delta_time)
 
         m_camera_controller.camera->position = config.camera_position;
         m_camera_controller.camera->target = config.camera_target;
+        m_camera_controller.camera->fov = config.fov;
+        m_camera_controller.camera->near = config.near;
+        m_camera_controller.camera->far = config.far;
+        m_camera_controller.type = config.camera_controller_type;
+        m_camera_controller.movement_speed = config.movement_speed;
+        m_camera_controller.rotation_speed = config.rotation_speed;
+        m_camera_controller.zoom_speed = config.zoom_speed;
 
         m_camera_controller.update(delta_time, ImGui::IsWindowFocused(), ImGui::IsWindowHovered());
 
@@ -48,13 +55,6 @@ void Viewport::render(double delta_time)
         } else {
             glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
         }
-        m_camera_controller.camera->fov = config.fov;
-        m_camera_controller.camera->near = config.near;
-        m_camera_controller.camera->far = config.far;
-        m_camera_controller.type = config.camera_controller_type;
-        m_camera_controller.movement_speed = config.movement_speed;
-        m_camera_controller.rotation_speed = config.rotation_speed;
-        m_camera_controller.zoom_speed = config.zoom_speed;
         m_camera_controller.camera->draw(config.viewing_mode, config.viewport_uniforms, m_framebuffer, *project->scene);
 
         if (project->selected_node) {


### PR DESCRIPTION
Previously, when loading a project using the Blender camera controller, the camera controller would first update using the default Unity controller, resulting in the pivot point being reset.